### PR TITLE
Feature/startup delay by player version fix

### DIFF
--- a/src/components/charts/performance/StartupDelayByPlayerVersion.js
+++ b/src/components/charts/performance/StartupDelayByPlayerVersion.js
@@ -31,7 +31,7 @@ class StartupDelayByPlayerVersion extends Component {
     const rows = await startupDelay.videoStartupDelayByPlayerVersion(apiKey, baseQuery);
     const playerVersions = new Set(rows.map(row => row[1]));
     const series = [...playerVersions].map((playerVersion) => ({
-      name: playerVersion ? playerVersion.toUpperCase() : '',
+      name: playerVersion ? playerVersion.toUpperCase() : 'Unknown',
       data: rows
         .filter(r => r[1] === playerVersion)
         .map(r => [r[0], Math.round(r[2])])

--- a/src/components/charts/performance/StartupDelayByPlayerVersion.js
+++ b/src/components/charts/performance/StartupDelayByPlayerVersion.js
@@ -31,7 +31,7 @@ class StartupDelayByPlayerVersion extends Component {
     const rows = await startupDelay.videoStartupDelayByPlayerVersion(apiKey, baseQuery);
     const playerVersions = new Set(rows.map(row => row[1]));
     const series = [...playerVersions].map((playerVersion) => ({
-      name: playerVersion.toUpperCase(),
+      name: playerVersion ? playerVersion.toUpperCase() : '',
       data: rows
         .filter(r => r[1] === playerVersion)
         .map(r => [r[0], Math.round(r[2])])


### PR DESCRIPTION
The chart `Startup delay by player version` would crash if the playerVersion is null. 
This happened e.g. for fubo.tv customer account.